### PR TITLE
CI: fix get logs client task

### DIFF
--- a/testsuite/dockerfiles/ubuntu-minion/Dockerfile
+++ b/testsuite/dockerfiles/ubuntu-minion/Dockerfile
@@ -3,7 +3,7 @@ RUN echo "deb [trusted=yes] http://download.opensuse.org/repositories/systemsman
 RUN apt-get update && \
   apt-get -y install ca-certificates && \
   apt-get -y install venv-salt-minion openssh-server openssh-client hostname iproute2 openscap-utils openscap-scanner openscap-common ssg-debderived udev dmidecode tar \
-    prometheus-node-exporter prometheus-apache-exporter prometheus-postgres-exporter prometheus-exporter-exporter prometheus-apache-exporter prometheus-node-exporter && \
+    prometheus-node-exporter prometheus-apache-exporter prometheus-postgres-exporter prometheus-exporter-exporter prometheus-apache-exporter prometheus-node-exporter xz && \
   apt-get clean
 RUN echo "deb [trusted=yes] http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb/ /" > /etc/apt/sources.list.d/test_repo_deb_pool.list
 RUN mkdir /run/sshd


### PR DESCRIPTION
## What does this PR change?

The ubuntu minion needs xz to compress the log files. Otherwise, the task "Get client logs" fails.

## GUI diff

No difference.



- [ ] **DONE**

## Documentation
- No documentation needed
- [ ] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [ ] **DONE**

## Links

Issue(s):N/A

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
