### PR TITLE
CI: skip cobbler logs flaky test

### DIFF
--- a/testsuite/features/secondary/srv_cobbler_sync.feature
+++ b/testsuite/features/secondary/srv_cobbler_sync.feature
@@ -42,5 +42,7 @@ Feature: Run Cobbler Sync via WebUI
     And I follow the left menu "Admin > Task Engine Status > Last Execution Times"
     Then I should see the correct timestamp for task "Cobbler Sync:"
 
+# flaky test
+@skip_if_github_validation
   Scenario: Check for errors in Cobbler monitoring
     Then the local logs for Cobbler should not contain errors


### PR DESCRIPTION
## What does this PR change?

This test fails on unrelated PRs. Any error will be catch in any case when running the whole testsuite with jenkins.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
ℹ️ If a major new functionality is added, it is **strongly recommended** that tests for the new functionality are added to the Cucumber test suite
- No tests

- [x] **DONE**

## Links

N/A

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

# Before you merge

Check [How to branch and merge properly](https://github.com/uyuni-project/uyuni/wiki/How-to-branch-and-merge-properly)!
